### PR TITLE
Uafaws 311- Install Sendmail on CentOS container and run SED in tomcat-ctl for SMTP value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
 RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail m4 sendmail-cf cyrus-sasl-plain
-yum install sendmail-cf -y
+RUN yum install sendmail-cf -y
 # RUN yum -y install sendmail m4
 
 # Edit /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 # Install Sendmail Services -UAFAWS-311
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
-RUN  yum -y install sendmail
+RUN yum clean all ; yum -y install sendmail 
 # Edit /etc/mail/authinfo
 COPY sendmail/authinfo /etc/mail/authinfo
 RUN touch /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 # Install Sendmail Services -UAFAWS-311
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
-RUN yum clean all ; yum -y install sendmail 
+RUN "rpm --rebuilddb; yum -y install sendmail 
 # Edit /etc/mail/authinfo
 COPY sendmail/authinfo /etc/mail/authinfo
 RUN touch /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,8 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 # Install Sendmail Services -UAFAWS-311
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
-RUN yum -y clean all && rpmdb --rebuilddb && \
-RUN yum -y install sendmail && m4 && \
+RUN yum -y clean all && rpmdb --rebuilddb
+RUN yum -y install sendmail && m4 
 RUN yum -y install -cf && -sasl-plain
 
 # Edit /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,6 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
 RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail m4 sendmail-cf cyrus-sasl-plain
-# RUN yum install sendmail-cf -y
-# RUN yum -y install sendmail m4
 
 # Edit /etc/mail/authinfo
 COPY sendmail/authinfo /etc/mail/authinfo
@@ -78,6 +76,8 @@ RUN cp /etc/mail/sendmail.cf /etc/mail/sendmail.cf.old
 #Update /etc/mail/sendmail.mc file with AWS Region info
 COPY sendmail/sendmail.mc /etc/mail/sendmail.mc
 RUN  sudo chmod 666 /etc/mail/sendmail.cf
+RUN  sudo m4 /etc/mail/sendmail.mc > /etc/mail/sendmail.cf
+RUN  sudo chmod 644 /etc/mail/sendmail.cf
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
 RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail m4 sendmail-cf cyrus-sasl-plain
-RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail-cf cyrus-sasl-plain
+#RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail-cf cyrus-sasl-plain
 # RUN yum -y install sendmail m4
 
 # Edit /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,8 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
 RUN yum -y clean all && rpmdb --rebuilddb
-RUN yum -y install sendmail && m4 
-RUN yum -y install -cf && -sasl-plain
+RUN yum -y install sendmail m4 
+RUN yum -y install sendmail-cf cyrus-sasl-plain
 
 # Edit /etc/mail/authinfo
 COPY sendmail/authinfo /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,8 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 # Install Sendmail Services -UAFAWS-311
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
-RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail
+RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail && yum -y install m4
+
 # Edit /etc/mail/authinfo
 COPY sendmail/authinfo /etc/mail/authinfo
 RUN touch /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,9 +55,9 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
 RUN yum -y clean all && rpmdb --rebuilddb
-RUN yum -y install sendmail m4
-RUN yum -y clean all && rpmdb --rebuilddb
 RUN yum -y install sendmail-cf cyrus-sasl-plain
+RUN yum -y clean all && rpmdb --rebuilddb
+RUN yum -y install sendmail m4
 
 # Edit /etc/mail/authinfo
 COPY sendmail/authinfo /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,10 +55,8 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
 RUN yum -y clean all && rpmdb --rebuilddb && \
-  yum -y install sendmail && \
-  yum -y install m4 && \
-  yum -y install -cf && \
-  yum -y install -sasl-plain
+RUN yum -y install sendmail && m4 && \
+RUN yum -y install -cf && -sasl-plain
 
 # Edit /etc/mail/authinfo
 COPY sendmail/authinfo /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,11 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 # Install Sendmail Services -UAFAWS-311
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
-RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail m4 sendmail-cf cyrus-sasl-plain
+RUN yum -y clean all && rpmdb --rebuilddb && \
+  yum -y install sendmail && \
+  yum -y install m4 && \
+  yum -y install -cf && \
+  yum -y install -sasl-plain
 
 # Edit /etc/mail/authinfo
 COPY sendmail/authinfo /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,8 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
 RUN yum -y clean all && rpmdb --rebuilddb
-RUN yum -y install sendmail m4 
+RUN yum -y install sendmail m4
+RUN yum -y clean all && rpmdb --rebuilddb
 RUN yum -y install sendmail-cf cyrus-sasl-plain
 
 # Edit /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
 RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail m4 sendmail-cf cyrus-sasl-plain
-RUN yum install sendmail-cf -y
+# RUN yum install sendmail-cf -y
 # RUN yum -y install sendmail m4
 
 # Edit /etc/mail/authinfo
@@ -78,8 +78,7 @@ RUN cp /etc/mail/sendmail.cf /etc/mail/sendmail.cf.old
 #Update /etc/mail/sendmail.mc file with AWS Region info
 COPY sendmail/sendmail.mc /etc/mail/sendmail.mc
 RUN  sudo chmod 666 /etc/mail/sendmail.cf
-RUN  sudo m4 /etc/mail/sendmail.mc > /etc/mail/sendmail.cf
-RUN  sudo chmod 644 /etc/mail/sendmail.cf
+
 
 
 ENTRYPOINT /usr/local/bin/tomcat-start

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,9 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 # Install Sendmail Services -UAFAWS-311
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
-RUN yum -y clean all && rpmdb --rebuilddb
-RUN yum -y install sendmail-cf cyrus-sasl-plain
+RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail m4 sendmail-cf cyrus-sasl-plain
 # RUN yum -y clean all && rpmdb --rebuilddb
-RUN yum -y install sendmail m4
+# RUN yum -y install sendmail m4
 
 # Edit /etc/mail/authinfo
 COPY sendmail/authinfo /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
 RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail m4 sendmail-cf cyrus-sasl-plain
-#RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail-cf cyrus-sasl-plain
+yum install sendmail-cf -y
 # RUN yum -y install sendmail m4
 
 # Edit /etc/mail/authinfo
@@ -65,6 +65,7 @@ RUN sed -i "s/USERNAME/$SES_USERNAME/" /etc/mail/authinfo
 #http://backreference.org/2010/02/20/using-different-delimiters-in-sed/
 #Because AWS SES credential has special character, switching Delimiter from / to #
 RUN sed -i "s#PASSWORD#$SES_PWD#" /etc/mail/authinfo
+#RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail-cf cyrus-sasl-plain
 RUN  sudo makemap hash /etc/mail/authinfo.db < /etc/mail/authinfo
 
 #Append /etc/mail/access file

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM 760232551367.dkr.ecr.us-west-2.amazonaws.com/kuali/tomcat7
 
+# Build AWS SES variables
+ARG SES_USERNAME=aws_ses_user
+ARG SES_PWD=aws_ses_pwd
+
 RUN groupadd -r kuali && useradd -r -g kuali kualiadm
 
 # copy in the tomcat utility scripts
@@ -7,10 +11,6 @@ COPY bin /usr/local/bin/
 
 # set kfs web app directory owner and group
 RUN chmod +x /usr/local/bin/*
-
-# Build AWS SES variables
-ARG SES_USERNAME=aws_ses_user
-ARG SES_PWD=aws_ses_pwd
 
 # create some useful shorcut environment variables
 ENV TOMCAT_BASE_DIR=$CATALINA_HOME

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
 RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail m4 sendmail-cf cyrus-sasl-plain
-# RUN yum -y clean all && rpmdb --rebuilddb
+RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail-cf cyrus-sasl-plain
 # RUN yum -y install sendmail m4
 
 # Edit /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 
 RUN yum -y clean all && rpmdb --rebuilddb
 RUN yum -y install sendmail-cf cyrus-sasl-plain
-RUN yum -y clean all && rpmdb --rebuilddb
+# RUN yum -y clean all && rpmdb --rebuilddb
 RUN yum -y install sendmail m4
 
 # Edit /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 # Install Sendmail Services -UAFAWS-311
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
-RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail && yum -y install m4
+RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail m4 sendmail-cf cyrus-sasl-plain
 
 # Edit /etc/mail/authinfo
 COPY sendmail/authinfo /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 # Install Sendmail Services -UAFAWS-311
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
-RUN  sudo apt-get -q -y install sendmail
+RUN  yum -y install sendmail
 # Edit /etc/mail/authinfo
 COPY sendmail/authinfo /etc/mail/authinfo
 RUN touch /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 # Install Sendmail Services -UAFAWS-311
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
-RUN rpm --rebuilddb && yum update && yum -y install sendmail 
+RUN yum -y clean all && rpmdb --rebuilddb && yum -y install sendmail
 # Edit /etc/mail/authinfo
 COPY sendmail/authinfo /etc/mail/authinfo
 RUN touch /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,8 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 # Install Sendmail Services -UAFAWS-311
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
-RUN "rpm --rebuilddb; yum -y install sendmail 
+RUN rpm --rebuilddb
+RUN yum -y install sendmail 
 # Edit /etc/mail/authinfo
 COPY sendmail/authinfo /etc/mail/authinfo
 RUN touch /etc/mail/authinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,7 @@ COPY files/kfs.war $TOMCAT_KFS_DIR/kfs.war
 # Install Sendmail Services -UAFAWS-311
 #http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html
 
-RUN rpm --rebuilddb
-RUN yum -y install sendmail 
+RUN rpm --rebuilddb && yum update && yum -y install sendmail 
 # Edit /etc/mail/authinfo
 COPY sendmail/authinfo /etc/mail/authinfo
 RUN touch /etc/mail/authinfo

--- a/bin/tomcat-ctl
+++ b/bin/tomcat-ctl
@@ -101,6 +101,8 @@ tomcat_start () {
     echo_time "Completed running liquibase update"
 
     # By default, sendmail service need to restart after installation
+    sudo m4 /etc/mail/sendmail.mc > /etc/mail/sendmail.cf
+    sudo chmod 644 /etc/mail/sendmail.cf
     sudo /etc/init.d/sendmail restart
 
 # Swap SMTP value to work for AWS

--- a/bin/tomcat-ctl
+++ b/bin/tomcat-ctl
@@ -101,8 +101,6 @@ tomcat_start () {
     echo_time "Completed running liquibase update"
 
     # By default, sendmail service need to restart after installation
-    sudo m4 /etc/mail/sendmail.mc > /etc/mail/sendmail.cf
-    sudo chmod 644 /etc/mail/sendmail.cf
     sudo /etc/init.d/sendmail restart
 
 # Swap SMTP value to work for AWS

--- a/bin/tomcat-ctl
+++ b/bin/tomcat-ctl
@@ -105,7 +105,7 @@ tomcat_start () {
 
 # Swap SMTP value to work for KFS 3 in AWS
     sed -i "s/mail.relay.server=smtpgate.email.arizona.edu/mail.relay.server=localhost" $TOMCAT_KFS_DIR/WEB-INF/classes/configuration.properties
-    sed -i '/mail.relay.server=localhost /a mail.smtp.host=email-localhost" $TOMCAT_KFS_DIR/WEB-INF/classes/configuration.properties
+    sed -i '/mail.relay.server=localhost /a mail.smtp.host=email-localhost' $TOMCAT_KFS_DIR/WEB-INF/classes/configuration.properties
 
     # set up setenv.sh script for export of environment variables
     cp $TOMCAT_CONFIG_DIRECTORY/setenv.sh $TOMCAT_SHARE_BIN/setenv.sh

--- a/bin/tomcat-ctl
+++ b/bin/tomcat-ctl
@@ -100,7 +100,10 @@ tomcat_start () {
     log "Completed running liquibase update"
     echo_time "Completed running liquibase update"
 
-    # Swap SMTP value to work for AWS
+    # By default, sendmail service need to restart after installation
+    sudo /etc/init.d/sendmail restart
+
+# Swap SMTP value to work for AWS
     sed -i "s/mail.smtp.host=smtp.local/mail.smtp.host=email-smtp.us-west-2.amazonaws.com/" $TOMCAT_KFS_CORE_DIR/institutional-config.properties
     sed -i "s/mail.smtp.port=25/mail.smtp.port=587/" $TOMCAT_KFS_CORE_DIR/institutional-config.properties
     sed -i "s/mail.smtp.starttls.enable=false/mail.smtp.starttls.enable=true/" $TOMCAT_KFS_CORE_DIR/institutional-config.properties

--- a/bin/tomcat-ctl
+++ b/bin/tomcat-ctl
@@ -103,11 +103,9 @@ tomcat_start () {
     # By default, sendmail service need to restart after installation
     sudo /etc/init.d/sendmail restart
 
-# Swap SMTP value to work for AWS
-    sed -i "s/mail.smtp.host=smtp.local/mail.smtp.host=email-smtp.us-west-2.amazonaws.com/" $TOMCAT_KFS_CORE_DIR/institutional-config.properties
-    sed -i "s/mail.smtp.port=25/mail.smtp.port=587/" $TOMCAT_KFS_CORE_DIR/institutional-config.properties
-    sed -i "s/mail.smtp.starttls.enable=false/mail.smtp.starttls.enable=true/" $TOMCAT_KFS_CORE_DIR/institutional-config.properties
-    sed -i "s/mail.smtp.auth=false/mail.smtp.auth=true/" $TOMCAT_KFS_CORE_DIR/institutional-config.properties
+# Swap SMTP value to work for KFS 3 in AWS
+    sed -i "s/mail.relay.server=smtpgate.email.arizona.edu/mail.relay.server=localhost" $TOMCAT_KFS_DIR/WEB-INF/classes/configuration.properties
+    sed -i '/mail.relay.server=localhost /a mail.smtp.host=email-localhost" $TOMCAT_KFS_DIR/WEB-INF/classes/configuration.properties
 
     # set up setenv.sh script for export of environment variables
     cp $TOMCAT_CONFIG_DIRECTORY/setenv.sh $TOMCAT_SHARE_BIN/setenv.sh

--- a/bin/tomcat-ctl
+++ b/bin/tomcat-ctl
@@ -105,8 +105,8 @@ tomcat_start () {
 
 # Swap SMTP value to work for KFS 3 in AWS
     sed -i "s/mail.relay.server=smtpgate.email.arizona.edu/mail.relay.server=localhost/" $TOMCAT_KFS_DIR/WEB-INF/classes/configuration.properties
-    sed -i '/mail.relay.server=localhost/a mail.smtp.host=email-localhost' $TOMCAT_KFS_DIR/WEB-INF/classes/configuration.properties
-
+    sed -i "s/mail.smtp.host=smtpgate.email.arizona.edu/mail.smtp.host=localhost/" $TOMCAT_KFS_DIR/WEB-INF/classes/configuration.properties
+      
     # set up setenv.sh script for export of environment variables
     cp $TOMCAT_CONFIG_DIRECTORY/setenv.sh $TOMCAT_SHARE_BIN/setenv.sh
     chmod +x $TOMCAT_SHARE_BIN/setenv.sh

--- a/bin/tomcat-ctl
+++ b/bin/tomcat-ctl
@@ -104,8 +104,8 @@ tomcat_start () {
     sudo /etc/init.d/sendmail restart
 
 # Swap SMTP value to work for KFS 3 in AWS
-    sed -i "s/mail.relay.server=smtpgate.email.arizona.edu/mail.relay.server=localhost" $TOMCAT_KFS_DIR/WEB-INF/classes/configuration.properties
-    sed -i '/mail.relay.server=localhost /a mail.smtp.host=email-localhost' $TOMCAT_KFS_DIR/WEB-INF/classes/configuration.properties
+    sed -i "s/mail.relay.server=smtpgate.email.arizona.edu/mail.relay.server=localhost/" $TOMCAT_KFS_DIR/WEB-INF/classes/configuration.properties
+    sed -i '/mail.relay.server=localhost/a mail.smtp.host=email-localhost' $TOMCAT_KFS_DIR/WEB-INF/classes/configuration.properties
 
     # set up setenv.sh script for export of environment variables
     cp $TOMCAT_CONFIG_DIRECTORY/setenv.sh $TOMCAT_SHARE_BIN/setenv.sh

--- a/sendmail/authinfo
+++ b/sendmail/authinfo
@@ -1,0 +1,1 @@
+AuthInfo:email-smtp.us-west-2.amazonaws.com "U:root" "I:USERNAME" "P:PASSWORD" "M:LOGIN"

--- a/sendmail/sendmail.mc
+++ b/sendmail/sendmail.mc
@@ -1,110 +1,183 @@
 divert(-1)dnl
-#-----------------------------------------------------------------------------
-# $Sendmail: debproto.mc,v 8.14.4 2014-02-11 13:02:08 cowboy Exp $
-#
-# Copyright (c) 1998-2010 Richard Nelson.  All Rights Reserved.
-#
-# cf/debian/sendmail.mc.  Generated from sendmail.mc.in by configure.
-#
-# sendmail.mc prototype config file for building Sendmail 8.14.4
-#
-# Note: the .in file supports 8.7.6 - 9.0.0, but the generated
-#	file is customized to the version noted above.
-#
-# This file is used to configure Sendmail for use with Debian systems.
-#
-# If you modify this file, you will have to regenerate /etc/mail/sendmail.cf
-# by running this file through the m4 preprocessor via one of the following:
-#	* make   (or make -C /etc/mail)
-#	* sendmailconfig 
-#	* m4 /etc/mail/sendmail.mc > /etc/mail/sendmail.cf
-# The first two options are preferred as they will also update other files
-# that depend upon the contents of this file.
-#
-# The best documentation for this .mc file is:
-# /usr/share/doc/sendmail-doc/cf.README.gz
-#
-#-----------------------------------------------------------------------------
-divert(0)dnl
-#
-#   Copyright (c) 1998-2005 Richard Nelson.  All Rights Reserved.
-#
-#  This file is used to configure Sendmail for use with Debian systems.
-#
-define(`_USE_ETC_MAIL_')dnl
-include(`/usr/share/sendmail/cf/m4/cf.m4')dnl
-VERSIONID(`$Id: sendmail.mc, v 8.14.4-4.1ubuntu1 2014-02-11 13:02:08 cowboy Exp $')
-OSTYPE(`debian')dnl
-DOMAIN(`debian-mta')dnl
-dnl # Items controlled by /etc/mail/sendmail.conf - DO NOT TOUCH HERE
-undefine(`confHOST_STATUS_DIRECTORY')dnl        #DAEMON_HOSTSTATS=
-dnl # Items controlled by /etc/mail/sendmail.conf - DO NOT TOUCH HERE
 dnl #
-dnl # General defines
+dnl # This is the sendmail macro config file for m4. If you make changes to
+dnl # /etc/mail/sendmail.mc, you will need to regenerate the
+dnl # /etc/mail/sendmail.cf file by confirming that the sendmail-cf package is
+dnl # installed and then performing a
 dnl #
-dnl # SAFE_FILE_ENV: [undefined] If set, sendmail will do a chroot()
-dnl #	into this directory before writing files.
-dnl #	If *all* your user accounts are under /home then use that
-dnl #	instead - it will prevent any writes outside of /home !
-dnl #   define(`confSAFE_FILE_ENV',             `')dnl
+dnl #     /etc/mail/make
 dnl #
-dnl # Daemon options - restrict to servicing LOCALHOST ONLY !!!
-dnl # Remove `, Addr=' clauses to receive from any interface
-dnl # If you want to support IPv6, switch the commented/uncommentd lines
+include(`/usr/share/sendmail-cf/m4/cf.m4')dnl
+VERSIONID(`setup for linux')dnl
+OSTYPE(`linux')dnl
 dnl #
-FEATURE(`no_default_msa')dnl
-dnl DAEMON_OPTIONS(`Family=inet6, Name=MTA-v6, Port=smtp, Addr=::1')dnl
-DAEMON_OPTIONS(`Family=inet,  Name=MTA-v4, Port=smtp, Addr=127.0.0.1')dnl
-dnl DAEMON_OPTIONS(`Family=inet6, Name=MSP-v6, Port=submission, M=Ea, Addr=::1')dnl
-DAEMON_OPTIONS(`Family=inet,  Name=MSP-v4, Port=submission, M=Ea, Addr=127.0.0.1')dnl
+dnl # Do not advertize sendmail version.
 dnl #
-dnl # Be somewhat anal in what we allow
-define(`confPRIVACY_FLAGS',dnl
-`needmailhelo,needexpnhelo,needvrfyhelo,restrictqrun,restrictexpand,nobodyreturn,authwarnings')dnl
+dnl define(`confSMTP_LOGIN_MSG', `$j Sendmail; $b')dnl
 dnl #
-dnl # Define connection throttling and window length
-define(`confCONNECTION_RATE_THROTTLE', `15')dnl
-define(`confCONNECTION_RATE_WINDOW_SIZE',`10m')dnl
+dnl # default logging level is 9, you might want to set it higher to
+dnl # debug the configuration
 dnl #
-dnl # Features
+dnl define(`confLOG_LEVEL', `9')dnl
 dnl #
-dnl # use /etc/mail/local-host-names
-FEATURE(`use_cw_file')dnl
+dnl # Uncomment and edit the following line if your outgoing mail needs to
+dnl # be sent out through an external mail server:
 dnl #
-dnl # The access db is the basis for most of sendmail's checking
-FEATURE(`access_db', , `skip')dnl
+dnl define(`SMART_HOST', `smtp.your.provider')dnl
 dnl #
-dnl # The greet_pause feature stops some automail bots - but check the
-dnl # provided access db for details on excluding localhosts...
-FEATURE(`greet_pause', `1000')dnl 1 seconds
+define(`confDEF_USER_ID', ``8:12'')dnl
+dnl define(`confAUTO_REBUILD')dnl
+define(`confTO_CONNECT', `1m')dnl
+define(`confTRY_NULL_MX_LIST', `True')dnl
+define(`confDONT_PROBE_INTERFACES', `True')dnl
+define(`PROCMAIL_MAILER_PATH', `/usr/bin/procmail')dnl
+define(`ALIAS_FILE', `/etc/aliases')dnl
+define(`STATUS_FILE', `/var/log/mail/statistics')dnl
+define(`UUCP_MAILER_MAX', `2000000')dnl
+define(`confUSERDB_SPEC', `/etc/mail/userdb.db')dnl
+define(`confPRIVACY_FLAGS', `authwarnings,novrfy,noexpn,restrictqrun')dnl
+define(`confAUTH_OPTIONS', `A')dnl
 dnl #
-dnl # Delay_checks allows sender<->recipient checking
-FEATURE(`delay_checks', `friend', `n')dnl
+dnl # The following allows relaying if the user authenticates, and disallows
+dnl # plaintext authentication (PLAIN/LOGIN) on non-TLS links
 dnl #
-dnl # If we get too many bad recipients, slow things down...
-define(`confBAD_RCPT_THROTTLE',`3')dnl
+dnl define(`confAUTH_OPTIONS', `A p')dnl
 dnl #
-dnl # Stop connections that overflow our concurrent and time connection rates
-FEATURE(`conncontrol', `nodelay', `terminate')dnl
-FEATURE(`ratecontrol', `nodelay', `terminate')dnl
+dnl # PLAIN is the preferred plaintext authentication method and used by
+dnl # Mozilla Mail and Evolution, though Outlook Express and other MUAs do
+dnl # use LOGIN. Other mechanisms should be used if the connection is not
+dnl # guaranteed secure.
+dnl # Please remember that saslauthd needs to be running for AUTH.
 dnl #
-dnl # If you're on a dialup link, you should enable this - so sendmail
-dnl # will not bring up the link (it will queue mail for later)
-dnl define(`confCON_EXPENSIVE',`True')dnl
+dnl TRUST_AUTH_MECH(`EXTERNAL DIGEST-MD5 CRAM-MD5 LOGIN PLAIN')dnl
+dnl define(`confAUTH_MECHANISMS', `EXTERNAL GSSAPI DIGEST-MD5 CRAM-MD5 LOGIN PLAIN')dnl
 dnl #
-dnl # Dialup/LAN connection overrides
+dnl # Rudimentary information on creating certificates for sendmail TLS:
+dnl #     cd /etc/pki/tls/certs; make sendmail.pem
+dnl # Complete usage:
+dnl #     make -C /etc/pki/tls/certs usage
 dnl #
-include(`/etc/mail/m4/dialup.m4')dnl
-include(`/etc/mail/m4/provider.m4')dnl
+dnl define(`confCACERT_PATH', `/etc/pki/tls/certs')dnl
+dnl define(`confCACERT', `/etc/pki/tls/certs/ca-bundle.crt')dnl
+dnl define(`confSERVER_CERT', `/etc/pki/tls/certs/sendmail.pem')dnl
+dnl define(`confSERVER_KEY', `/etc/pki/tls/certs/sendmail.pem')dnl
 dnl #
+dnl # This allows sendmail to use a keyfile that is shared with OpenLDAP's
+dnl # slapd, which requires the file to be readble by group ldap
+dnl #
+dnl define(`confDONT_BLAME_SENDMAIL', `groupreadablekeyfile')dnl
+dnl #
+dnl define(`confTO_QUEUEWARN', `4h')dnl
+dnl define(`confTO_QUEUERETURN', `5d')dnl
+dnl define(`confQUEUE_LA', `12')dnl
+dnl define(`confREFUSE_LA', `18')dnl
+define(`confTO_IDENT', `0')dnl
+dnl FEATURE(delay_checks)dnl
+FEATURE(`no_default_msa', `dnl')dnl
+FEATURE(`smrsh', `/usr/sbin/smrsh')dnl
+FEATURE(`mailertable', `hash -o /etc/mail/mailertable.db')dnl
+FEATURE(`virtusertable', `hash -o /etc/mail/virtusertable.db')dnl
+FEATURE(redirect)dnl
+FEATURE(always_add_domain)dnl
+FEATURE(use_cw_file)dnl
+FEATURE(use_ct_file)dnl
+dnl #
+dnl # The following limits the number of processes sendmail can fork to accept
+dnl # incoming messages or process its message queues to 20.) sendmail refuses
+dnl # to accept connections once it has reached its quota of child processes.
+dnl #
+dnl define(`confMAX_DAEMON_CHILDREN', `20')dnl
+dnl #
+dnl # Limits the number of new connections per second. This caps the overhead
+dnl # incurred due to forking new sendmail processes. May be useful against
+dnl # DoS attacks or barrages of spam. (As mentioned below, a per-IP address
+dnl # limit would be useful but is not available as an option at this writing.)
+dnl #
+dnl define(`confCONNECTION_RATE_THROTTLE', `3')dnl
+dnl #
+dnl # The -t option will retry delivery if e.g. the user runs over his quota.
+dnl #
+FEATURE(local_procmail, `', `procmail -t -Y -a $h -d $u')dnl
+FEATURE(`access_db', `hash -T<TMPF> -o /etc/mail/access.db')dnl
+FEATURE(`blacklist_recipients')dnl
+EXPOSED_USER(`root')dnl
+dnl #
+dnl # For using Cyrus-IMAPd as POP3/IMAP server through LMTP delivery uncomment
+dnl # the following 2 definitions and activate below in the MAILER section the
+dnl # cyrusv2 mailer.
+dnl #
+dnl define(`confLOCAL_MAILER', `cyrusv2')dnl
+dnl define(`CYRUSV2_MAILER_ARGS', `FILE /var/lib/imap/socket/lmtp')dnl
+dnl #
+dnl # The following causes sendmail to only listen on the IPv4 loopback address
+dnl # 127.0.0.1 and not on any other network devices. Remove the loopback
+dnl # address restriction to accept email from the internet or intranet.
+dnl #
+DAEMON_OPTIONS(`Port=smtp,Addr=127.0.0.1, Name=MTA')dnl
+dnl #
+dnl # The following causes sendmail to additionally listen to port 587 for
+dnl # mail from MUAs that authenticate. Roaming users who can't reach their
+dnl # preferred sendmail daemon due to port 25 being blocked or redirected find
+dnl # this useful.
+dnl #
+dnl DAEMON_OPTIONS(`Port=submission, Name=MSA, M=Ea')dnl
+dnl #
+dnl # The following causes sendmail to additionally listen to port 465, but
+dnl # starting immediately in TLS mode upon connecting. Port 25 or 587 followed
+dnl # by STARTTLS is preferred, but roaming clients using Outlook Express can't
+dnl # do STARTTLS on ports other than 25. Mozilla Mail can ONLY use STARTTLS
+dnl # and doesn't support the deprecated smtps; Evolution <1.1.1 uses smtps
+dnl # when SSL is enabled-- STARTTLS support is available in version 1.1.1.
+dnl #
+dnl # For this to work your OpenSSL certificates must be configured.
+dnl #
+dnl DAEMON_OPTIONS(`Port=smtps, Name=TLSMTA, M=s')dnl
+dnl #
+dnl # The following causes sendmail to additionally listen on the IPv6 loopback
+dnl # device. Remove the loopback address restriction listen to the network.
+dnl #
+dnl DAEMON_OPTIONS(`port=smtp,Addr=::1, Name=MTA-v6, Family=inet6')dnl
+dnl #
+dnl # enable both ipv6 and ipv4 in sendmail:
+dnl #
+dnl DAEMON_OPTIONS(`Name=MTA-v4, Family=inet, Name=MTA-v6, Family=inet6')
+dnl #
+dnl # We strongly recommend not accepting unresolvable domains if you want to
+dnl # protect yourself from spam. However, the laptop and users on computers
+dnl # that do not have 24x7 DNS do need this.
+dnl #
+FEATURE(`accept_unresolvable_domains')dnl
+dnl #
+dnl FEATURE(`relay_based_on_MX')dnl
+dnl #
+dnl # Also accept email sent to "localhost.localdomain" as local email.
+dnl #
+LOCAL_DOMAIN(`localhost.localdomain')dnl
+dnl #
+dnl # The following example makes mail from this host and any additional
+dnl # specified domains appear to be sent from mydomain.com
+dnl #
+dnl MASQUERADE_AS(`mydomain.com')dnl
+dnl #
+dnl # masquerade not just the headers, but the envelope as well
+dnl #
+dnl FEATURE(masquerade_envelope)dnl
+dnl #
+dnl # masquerade not just @mydomainalias.com, but @*.mydomainalias.com as well
+dnl #
+dnl FEATURE(masquerade_entire_domain)dnl
+dnl #
+dnl MASQUERADE_DOMAIN(localhost)dnl
+dnl MASQUERADE_DOMAIN(localhost.localdomain)dnl
+dnl MASQUERADE_DOMAIN(mydomainalias.com)dnl
+dnl MASQUERADE_DOMAIN(mydomain.lan)dnl
 define(`SMART_HOST', `email-smtp.us-west-2.amazonaws.com')dnl
 define(`RELAY_MAILER_ARGS', `TCP $h 25')dnl
 define(`confAUTH_MECHANISMS', `LOGIN PLAIN')dnl
 FEATURE(`authinfo', `hash -o /etc/mail/authinfo.db')dnl
-dnl # MASQUERADE_AS(`YOUR_DOMAIN')dnl
+MASQUERADE_AS(`YOUR_DOMAIN')dnl
 FEATURE(masquerade_envelope)dnl
 FEATURE(masquerade_entire_domain)dnl
-dnl # Default Mailer setup
-MAILER_DEFINITIONS
-MAILER(`local')dnl
-MAILER(`smtp')dnl
+MAILER(smtp)dnl
+MAILER(procmail)dnl
+dnl MAILER(cyrusv2)dnl

--- a/sendmail/sendmail.mc
+++ b/sendmail/sendmail.mc
@@ -1,0 +1,110 @@
+divert(-1)dnl
+#-----------------------------------------------------------------------------
+# $Sendmail: debproto.mc,v 8.14.4 2014-02-11 13:02:08 cowboy Exp $
+#
+# Copyright (c) 1998-2010 Richard Nelson.  All Rights Reserved.
+#
+# cf/debian/sendmail.mc.  Generated from sendmail.mc.in by configure.
+#
+# sendmail.mc prototype config file for building Sendmail 8.14.4
+#
+# Note: the .in file supports 8.7.6 - 9.0.0, but the generated
+#	file is customized to the version noted above.
+#
+# This file is used to configure Sendmail for use with Debian systems.
+#
+# If you modify this file, you will have to regenerate /etc/mail/sendmail.cf
+# by running this file through the m4 preprocessor via one of the following:
+#	* make   (or make -C /etc/mail)
+#	* sendmailconfig 
+#	* m4 /etc/mail/sendmail.mc > /etc/mail/sendmail.cf
+# The first two options are preferred as they will also update other files
+# that depend upon the contents of this file.
+#
+# The best documentation for this .mc file is:
+# /usr/share/doc/sendmail-doc/cf.README.gz
+#
+#-----------------------------------------------------------------------------
+divert(0)dnl
+#
+#   Copyright (c) 1998-2005 Richard Nelson.  All Rights Reserved.
+#
+#  This file is used to configure Sendmail for use with Debian systems.
+#
+define(`_USE_ETC_MAIL_')dnl
+include(`/usr/share/sendmail/cf/m4/cf.m4')dnl
+VERSIONID(`$Id: sendmail.mc, v 8.14.4-4.1ubuntu1 2014-02-11 13:02:08 cowboy Exp $')
+OSTYPE(`debian')dnl
+DOMAIN(`debian-mta')dnl
+dnl # Items controlled by /etc/mail/sendmail.conf - DO NOT TOUCH HERE
+undefine(`confHOST_STATUS_DIRECTORY')dnl        #DAEMON_HOSTSTATS=
+dnl # Items controlled by /etc/mail/sendmail.conf - DO NOT TOUCH HERE
+dnl #
+dnl # General defines
+dnl #
+dnl # SAFE_FILE_ENV: [undefined] If set, sendmail will do a chroot()
+dnl #	into this directory before writing files.
+dnl #	If *all* your user accounts are under /home then use that
+dnl #	instead - it will prevent any writes outside of /home !
+dnl #   define(`confSAFE_FILE_ENV',             `')dnl
+dnl #
+dnl # Daemon options - restrict to servicing LOCALHOST ONLY !!!
+dnl # Remove `, Addr=' clauses to receive from any interface
+dnl # If you want to support IPv6, switch the commented/uncommentd lines
+dnl #
+FEATURE(`no_default_msa')dnl
+dnl DAEMON_OPTIONS(`Family=inet6, Name=MTA-v6, Port=smtp, Addr=::1')dnl
+DAEMON_OPTIONS(`Family=inet,  Name=MTA-v4, Port=smtp, Addr=127.0.0.1')dnl
+dnl DAEMON_OPTIONS(`Family=inet6, Name=MSP-v6, Port=submission, M=Ea, Addr=::1')dnl
+DAEMON_OPTIONS(`Family=inet,  Name=MSP-v4, Port=submission, M=Ea, Addr=127.0.0.1')dnl
+dnl #
+dnl # Be somewhat anal in what we allow
+define(`confPRIVACY_FLAGS',dnl
+`needmailhelo,needexpnhelo,needvrfyhelo,restrictqrun,restrictexpand,nobodyreturn,authwarnings')dnl
+dnl #
+dnl # Define connection throttling and window length
+define(`confCONNECTION_RATE_THROTTLE', `15')dnl
+define(`confCONNECTION_RATE_WINDOW_SIZE',`10m')dnl
+dnl #
+dnl # Features
+dnl #
+dnl # use /etc/mail/local-host-names
+FEATURE(`use_cw_file')dnl
+dnl #
+dnl # The access db is the basis for most of sendmail's checking
+FEATURE(`access_db', , `skip')dnl
+dnl #
+dnl # The greet_pause feature stops some automail bots - but check the
+dnl # provided access db for details on excluding localhosts...
+FEATURE(`greet_pause', `1000')dnl 1 seconds
+dnl #
+dnl # Delay_checks allows sender<->recipient checking
+FEATURE(`delay_checks', `friend', `n')dnl
+dnl #
+dnl # If we get too many bad recipients, slow things down...
+define(`confBAD_RCPT_THROTTLE',`3')dnl
+dnl #
+dnl # Stop connections that overflow our concurrent and time connection rates
+FEATURE(`conncontrol', `nodelay', `terminate')dnl
+FEATURE(`ratecontrol', `nodelay', `terminate')dnl
+dnl #
+dnl # If you're on a dialup link, you should enable this - so sendmail
+dnl # will not bring up the link (it will queue mail for later)
+dnl define(`confCON_EXPENSIVE',`True')dnl
+dnl #
+dnl # Dialup/LAN connection overrides
+dnl #
+include(`/etc/mail/m4/dialup.m4')dnl
+include(`/etc/mail/m4/provider.m4')dnl
+dnl #
+define(`SMART_HOST', `email-smtp.us-west-2.amazonaws.com')dnl
+define(`RELAY_MAILER_ARGS', `TCP $h 25')dnl
+define(`confAUTH_MECHANISMS', `LOGIN PLAIN')dnl
+FEATURE(`authinfo', `hash -o /etc/mail/authinfo.db')dnl
+dnl # MASQUERADE_AS(`YOUR_DOMAIN')dnl
+FEATURE(masquerade_envelope)dnl
+FEATURE(masquerade_entire_domain)dnl
+dnl # Default Mailer setup
+MAILER_DEFINITIONS
+MAILER(`local')dnl
+MAILER(`smtp')dnl


### PR DESCRIPTION
Dockerfile -  Install Sendmail for CentOS container and  Pass SES credentials 
Tomcat-ctl -  Swap SMTP value to localhost for KFS java code to send email request to local spooling (KATTS-2680)
sendmail.mc - Generate required Sendmail driver file compatible with CentOS